### PR TITLE
Minor syntax changes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Bilkent University CS 102 Project
+
 ### Spring 2020-2021 Semester
+
 ### Group Members
+
 - 22002643 - **Vedat Eren Arıcan**
 - 22002733 - **Borga Haktan Bilen**
 - 22003211 - **Berkan Şahin**
@@ -8,9 +11,11 @@
 - 22003021 - **Berk Çakar**
 
 ## Project Details
+
 Project Name: **LabConnect** ~~(Project Labenport)~~
 
-Some features:
+### Some features:
+
 - Tutor-check queuing for lab sessions
 - Unit testing (TA-controlled way to determine state of student's code)
 - Version control for TA's to observe changes more easily
@@ -19,6 +24,7 @@ Some features:
 - And possibly more as the development progresses...
 
 ## To do list
+
  - [x] Reorganize project document
  - [ ] Send project submission
  - [ ] Etc...


### PR DESCRIPTION
While the current readme is syntactically valid Markdown, it does not adhere to the stricter [Pandoc Markdown Syntax Rules](https://pandoc.org/MANUAL.html#pandocs-markdown). Therefore I made some minor changes to the README so we can use pandoc to generate HTML or LaTeX files down the line if necessary.